### PR TITLE
fix swagger type

### DIFF
--- a/lib/Model/ResourceProperty.php
+++ b/lib/Model/ResourceProperty.php
@@ -66,7 +66,7 @@ class ResourceProperty implements ArrayAccess
         'notification_settings' => 'string',
         'size' => 'int',
         'previewable' => 'bool',
-        'direct_file' => 'string',
+        'direct_file' => '\ExaVault\Sdk\Model\DirectFile[]',
         'type' => 'string'
     ];
 


### PR DESCRIPTION
This PR related to the issue with getResourceList - "Array to string conversion" when trying to serialise object from ExaVault API